### PR TITLE
Implements remember-me functionality to make decryption easier

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -12,12 +12,14 @@
   },
   "dependencies": {
     "@types/lodash": "^4.14.110",
+    "localforage": "^1.7.2",
     "lodash": "^4.17.10",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-router-dom": "^4.3.1",
     "request": "2.87.0",
-    "set-cookie-parser": "^2.2.0"
+    "set-cookie-parser": "^2.2.0",
+    "tough-cookie-filestore": "^0.0.1"
   },
   "devDependencies": {
     "@types/jest": "^20.0.2",

--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -4,6 +4,6 @@ export function login(
   username: string,
   password: string
 ): recordService.RecordServiceResponse {
-  const data = { username, password };
+  const data = { username, password, remember_me: true };
   return recordService.post(`/login`, data);
 }

--- a/client/src/api/record_service.ts
+++ b/client/src/api/record_service.ts
@@ -1,9 +1,12 @@
 import * as requestMaster from "request";
 import { constants } from "../config";
 import { resolve } from "url";
+const fileCookieStore = require("tough-cookie-filestore");
 
 export type RecordServiceResponse = Promise<requestMaster.Response>;
-const request = requestMaster.defaults({ jar: true });
+
+const jar = requestMaster.jar(new fileCookieStore(constants.COOKIE_STORAGE));
+const request = requestMaster.defaults({ jar });
 
 export function get(endpoint: string): RecordServiceResponse {
   return new Promise((pResolve, pReject) => {

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,9 +1,13 @@
+import { app, remote } from "electron";
+import { join } from "path";
 const penv = process.env;
 
 const RECORD_SERVICE_HOST = penv.RECORD_SERVICE_HOST || "http://localhost";
 const RECORD_SERVICE_PORT = penv.RECORD_SERVICE_PORT || 5000;
+const userDataPath = (app || remote.app).getPath("userData");
 
 export const constants = {
   RECORD_SERVICE_ENDPOINT: `${RECORD_SERVICE_HOST}:${RECORD_SERVICE_PORT}`,
-  LOGGEDIN_USER: "isLoggedIn"
+  LOGGEDIN_USER: "isLoggedIn",
+  COOKIE_STORAGE: join(userDataPath, "cookies.json")
 };

--- a/client/src/main/index.ts
+++ b/client/src/main/index.ts
@@ -1,12 +1,23 @@
-'use strict';
+"use strict";
 
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow } from "electron";
+import { existsSync, openSync, closeSync, appendFileSync } from "fs";
+import { constants } from "../config";
 
-const isDevelopment = process.env.NODE_ENV !== 'production';
+const isDevelopment = process.env.NODE_ENV !== "production";
 
 // Global reference to mainWindow
 // Necessary to prevent win from being garbage collected
 let mainWindow: Electron.BrowserWindow | null;
+
+function ensurePath() {
+  if (!existsSync(constants.COOKIE_STORAGE)) {
+    // Touch a cookie storage file if not exists
+    const fd = openSync(constants.COOKIE_STORAGE, "w");
+    appendFileSync(fd, "{}", "utf-8");
+    closeSync(fd);
+  }
+}
 
 function createMainWindow() {
   // Construct new BrowserWindow
@@ -25,34 +36,35 @@ function createMainWindow() {
 
   window.loadURL(url);
 
-  window.on('closed', () => {
+  window.on("closed", () => {
     mainWindow = null;
   });
 
-  window.webContents.on('devtools-opened', () => {
+  window.webContents.on("devtools-opened", () => {
     window.focus();
     setImmediate(() => {
       window.focus();
     });
   });
 
+  ensurePath();
   return window;
 }
 
 // Quit application when all windows are closed
-app.on('window-all-closed', () => {
+app.on("window-all-closed", () => {
   // On macOS it is common for applications to stay open
   // until the user explicitly quits
-  if (process.platform !== 'darwin') app.quit();
+  if (process.platform !== "darwin") app.quit();
 });
 
-app.on('activate', () => {
+app.on("activate", () => {
   // On macOS it is common to re-create a window
   // even after all windows have been closed
   if (mainWindow === null) mainWindow = createMainWindow();
 });
 
 // Create main BrowserWindow when electron is ready
-app.on('ready', () => {
+app.on("ready", () => {
   mainWindow = createMainWindow();
 });

--- a/client/src/renderer/home/home.tsx
+++ b/client/src/renderer/home/home.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import { Login } from "../authFlow/login";
 import { Error } from "../components/notifications/error";
 import { RecordList } from "./recordList";
+import * as localForage from "localforage";
+import { constants } from "../../config";
 
 type HomeState = {
   userData: string;
@@ -20,11 +22,19 @@ export class Home extends React.Component<{}, HomeState> {
 
   handleLogin = (userInternal: UserInternal | undefined): void => {
     this.setState({ userInternal });
+    localForage.setItem(constants.LOGGEDIN_USER, userInternal);
   };
 
   handleError = (errorMessage: string): void => {
     this.setState({ errorMessage });
   };
+
+  componentWillMount() {
+    localForage.getItem(constants.LOGGEDIN_USER).then(item => {
+      const userInternal = item as UserInternal;
+      this.setState({ userInternal });
+    });
+  }
 
   render() {
     const mainElem = this.state.userInternal ? (

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3235,6 +3235,10 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+
 import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
@@ -3736,6 +3740,12 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  dependencies:
+    immediate "~3.0.5"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -3775,6 +3785,12 @@ loader-utils@^1.0.2, loader-utils@^1.1.0:
     big.js "^3.1.3"
     emojis-list "^2.0.0"
     json5 "^0.5.0"
+
+localforage@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.7.2.tgz#fa4442602f806edd2bca6a54ab4e656f031f121c"
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -4910,13 +4926,13 @@ punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
 
+punycode@>=0.2.0, punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+
 punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-
-punycode@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
 q@^1.1.2:
   version "1.5.1"
@@ -5937,6 +5953,18 @@ to-regex@^3.0.1, to-regex@^3.0.2:
 toposort@^1.0.0:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
+
+tough-cookie-filestore@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/tough-cookie-filestore/-/tough-cookie-filestore-0.0.1.tgz#0bf2308ed293a50ba0733ed7d6289601485570b6"
+  dependencies:
+    tough-cookie "~0.12.1"
+
+tough-cookie@~0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-0.12.1.tgz#8220c7e21abd5b13d96804254bd5a81ebf2c7d62"
+  dependencies:
+    punycode ">=0.2.0"
 
 tough-cookie@~2.3.3:
   version "2.3.4"

--- a/record_service/record_service/endpoints/authentication/auth_api.py
+++ b/record_service/record_service/endpoints/authentication/auth_api.py
@@ -38,9 +38,11 @@ def login():
     if not User.check_password(u.hashed_password, data["password"]):
         return "Invalid password", 401
 
+    remember_me = data.get("remember_me", False)
+
     # sets the token in the response header, alternatively we can also return
     # the token in the response body
-    login_user(u)
+    login_user(u, remember=remember_me)
     return "Success", 200
 
 


### PR DESCRIPTION
1. Adds `remember_me` to both client and server side to allow for long living sessions. This makes testing and development easier as we don't really have to deal with auth logic.
2. Stores cookies locally instead of using session-based storage. Remember me auth requires using a long lived token which the client needs to persist between sessions. As such, app-storage needs to be used.

More testing with this stuff is required, but for now it should be good enough for MVP