### PR TITLE
Lazily connect to IPFS in record-srv

### DIFF
--- a/record_service/record_service/utils/file_uploader.py
+++ b/record_service/record_service/utils/file_uploader.py
@@ -23,10 +23,17 @@ class MockWriter(FsWriter):
 
 class IpfsWriter(FsWriter):
     def __init__(self):
-        self._client = ipfsapi.connect(host=IPFS_HOST, port=IPFS_PORT)
+        self._client = None
+
+    # Lazily connect to handle case where record-srv deploys before IPFS
+    @property
+    def client(self):
+        if self._client is None:
+            self._client = ipfsapi.connect(host=IPFS_HOST, port=IPFS_PORT)
+        return self._client
 
     def write(self, fp: str) -> dict:
-        return self._client.add(fp)
+        return self.client.add(fp)
 
 
 class FileUploader:


### PR DESCRIPTION
Connects to IPFS when needed rather than on construction to handle dependency issues with deploy