### PR TITLE
Quotes paths in exec

### DIFF
--- a/client/src/api/records.ts
+++ b/client/src/api/records.ts
@@ -55,7 +55,9 @@ export function encryptFileAndUpload(
   return (async () => {
     const encFilePath = await tmpName();
     await exec(
-      `src/scripts/encrypt_file.sh ${file.path} ${encFilePath} ${aesKey} ${iv}`
+      `src/scripts/encrypt_file.sh "${
+        file.path
+      }" "${encFilePath}" "${aesKey}" "${iv}"`
     );
     const form = {
       permissions: JSON.stringify(permissions),

--- a/client/src/api/users.ts
+++ b/client/src/api/users.ts
@@ -23,10 +23,10 @@ export function createUser(
       prefix: "medfstmp-"
     });
     await util.promisify(fs.writeFile)(path, password);
-    const privKey = await exec(`src/scripts/gen_pk.sh ${path}`);
+    const privKey = await exec(`src/scripts/gen_pk.sh "${path}"`);
     // TODO: Figure out how to pipe privKey into stdin instead of echo
     const pubKey = await exec(
-      `echo "${privKey}" | src/scripts/extract_pub.sh ${path}`
+      `echo "${privKey}" | src/scripts/extract_pub.sh "${path}"`
     );
     cleanup();
     const data = {


### PR DESCRIPTION
JS doesn't seem to have a nice shell escape function so to fix the bug of having spaces in a file path for now, just adding quotes.