### PR TITLE
Send a notification to ourselves containing key used to encrypt record

### DIFF
--- a/client/src/renderer/app.tsx
+++ b/client/src/renderer/app.tsx
@@ -91,7 +91,6 @@ class AppInner extends React.Component<RouteComponentProps<{}>, AppState> {
       this.setState(prevState => ({
         notifications: [...prevState.notifications, notification]
       }));
-      // Cache this value
     }
   };
 


### PR DESCRIPTION
If we don't specify any other users to share a newly uploaded record with the key never gets sent out and is lost forever. This change adds the current user to the list of permissioned users by default, meaning that we send a notification to ourselves containing the key.