### PR TITLE
Split deploys for core services and message srv

### DIFF
--- a/config/deploy/deploy.sh
+++ b/config/deploy/deploy.sh
@@ -2,11 +2,20 @@
 
 cd config/deploy/
 
-echo "Composing"
-ecs-cli compose --project-name medfs service up \
+echo "Composing core"
+ecs-cli compose -f docker-compose.core.yml --project-name medfs-core service up \
+   --cluster-config default \
+   --launch-type FARGATE \
+   # Uncomment the lines below if you need to recreate the service. Otherwise ecs-cli throws a warning
+   # --container-name record_service \
+   # --container-port 5000 \
+   # --target-group-arn arn:aws:elasticloadbalancing:us-east-1:361641763854:targetgroup/medfs-core/0b6fc21eb62b8100 \ 
+
+echo "Composing message service"
+ecs-cli compose -f docker-compose.message-srv.yml --project-name medfs-message service up \
     --cluster-config default \
     --launch-type FARGATE \
     # Uncomment the lines below if you need to recreate the service. Otherwise ecs-cli throws a warning
-    # --container-name record_service \
-    # --container-port 5000 \
-    # --target-group-arn arn:aws:elasticloadbalancing:us-east-1:361641763854:targetgroup/medfs/70ace18547f60eb7 \
+    # --container-name message_service \
+    # --container-port 5004 \
+    # --target-group-arn arn:aws:elasticloadbalancing:us-east-1:361641763854:targetgroup/medfs-message/06bc20ff6087f77b \

--- a/config/deploy/docker-compose.core.yml
+++ b/config/deploy/docker-compose.core.yml
@@ -16,22 +16,6 @@ services:
         awslogs-region: us-east-1
         awslogs-stream-prefix: record_service
 
-  message_service:
-    ports:
-      - "5004:5004"
-    env_file:
-      - message_service.env
-      - secrets/message_service_secrets.env
-    environment:
-      - PYTHONUNBUFFERED=0 # Causes print statements to be logged
-    image: "361641763854.dkr.ecr.us-east-1.amazonaws.com/message_service:latest"
-    logging:
-      driver: awslogs
-      options:
-        awslogs-group: medfs
-        awslogs-region: us-east-1
-        awslogs-stream-prefix: message_service
-
   ipfs:
     image: jbenet/go-ipfs:latest
     ports:

--- a/config/deploy/docker-compose.message-srv.yml
+++ b/config/deploy/docker-compose.message-srv.yml
@@ -1,0 +1,18 @@
+version: "3.0"
+services:
+  message_service:
+    ports:
+      - "5004:5004"
+    env_file:
+      - message_service.env
+      - secrets/message_service_secrets.env
+    environment:
+      - PYTHONUNBUFFERED=0 # Causes print statements to be logged
+    image: "361641763854.dkr.ecr.us-east-1.amazonaws.com/message_service:latest"
+    logging:
+      driver: awslogs
+      options:
+        awslogs-group: medfs
+        awslogs-region: us-east-1
+        awslogs-stream-prefix: message_service
+

--- a/message_service/app.py
+++ b/message_service/app.py
@@ -1,9 +1,10 @@
 from aiohttp import web
 
 import config
-from message_service import stream_api
+from message_service import stream_api, healthcheck
 
 
 app = web.Application()
 app.router.add_route("GET", "/messages/stream/{uuid}", stream_api.stream)
+app.router.add_route("GET", "/healthcheck", healthcheck.healthcheck)
 web.run_app(app, host=config.APP_HOST, port=config.APP_PORT)

--- a/message_service/message_service/healthcheck.py
+++ b/message_service/message_service/healthcheck.py
@@ -1,0 +1,5 @@
+from aiohttp import web
+
+
+def healthcheck(request):
+    return web.Response(text="Healthy!")


### PR DESCRIPTION
Splitting message service into its own service so that we can reach it publicly, which wasn't possible when they were all under one service. This is required because we also need to reach message srv from the client.