### PR TITLE
Fix record-service db schema

### DIFF
--- a/record_service/app.py
+++ b/record_service/app.py
@@ -14,6 +14,9 @@ from record_service.models.base import Base
 from record_service.models.user import User  # noqa F401
 from record_service.models.record import Record  # noqa F401
 from record_service.models.record_key import RecordKey  # noqa F401
+from record_service.models.doctor import Doctor  # noqa F401
+from record_service.models.patient import Patient  # noqa F401
+from record_service.models.patient_doctors import PatientDoctors  # noqa F401
 
 # API Endpoints
 from record_service.endpoints.auth_api import auth_api

--- a/record_service/record_service/models/patient.py
+++ b/record_service/record_service/models/patient.py
@@ -12,6 +12,4 @@ class Patient(Base):
     __tablename__ = "patients"
 
     user_id = db.Column(UUID(as_uuid=True), db.ForeignKey(User.id), primary_key=True)
-    primary_physician = db.Column(
-        UUID(as_uuid=True), db.ForeignKey(Doctor.user_id), primary_key=True
-    )
+    primary_physician = db.Column(UUID(as_uuid=True), db.ForeignKey(Doctor.user_id))


### PR DESCRIPTION
In setting up benchmarks noticed our schema is actually broken because we can't have primary_physician also be a PK if the patients table is referenced in the many-to-many patients_doctors table, so removed that constraint. Also imported the newly added tables into app so they're created if they don't exist.