### PR TITLE
Fix encryption/decryption, other bugs

### DIFF
--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -4,7 +4,7 @@ import { ERR_NOT_AUTHORIZED } from "../models/errors";
 import { file } from "tmp-promise";
 import util from "util";
 import fs from "fs";
-const exec = util.promisify(require("child_process").exec);
+const execFile = util.promisify(require("child_process").execFile);
 
 export interface LoginDetails {
   userId: string;
@@ -52,9 +52,10 @@ export function decryptPk(
     });
     await util.promisify(fs.writeFile)(passwordPath, password);
 
-    const decryptedPk = await exec(
-      `src/scripts/decrypt_pk.sh "${pkPath}" "${passwordPath}"`
-    );
+    const decryptedPk = await execFile("src/scripts/decrypt_pk.sh", [
+      pkPath,
+      passwordPath
+    ]);
 
     pkFire();
     passwordCleanup();

--- a/client/src/api/records.ts
+++ b/client/src/api/records.ts
@@ -8,7 +8,7 @@ import { RecordItem, RecordDetails, RecordKey } from "../models/records";
 import { ERR_NOT_AUTHORIZED, ERR_NOT_LOGGED_IN } from "../models/errors";
 import * as crypto from "crypto";
 import { getLogin } from "../utils/loginUtils";
-const exec = util.promisify(require("child_process").exec);
+const execFile = util.promisify(require("child_process").execFile);
 
 type RecordServiceResponse = {
   id: string;
@@ -82,11 +82,12 @@ export function encryptFileAndUpload(
 ): recordService.RecordServiceResponse {
   return (async () => {
     const encFilePath = await tmpName();
-    await exec(
-      `src/scripts/encrypt_file.sh "${
-        file.path
-      }" "${encFilePath}" "${aesKey}" "${iv}"`
-    );
+    await execFile("src/scripts/encrypt_file.sh", [
+      file.path,
+      encFilePath,
+      aesKey,
+      iv
+    ]);
     const form = {
       permissions: JSON.stringify(permissions),
       extension,

--- a/client/src/scripts/decrypt_file.sh
+++ b/client/src/scripts/decrypt_file.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-openssl enc -aes-256-cbc -K $2 -iv $3 -in $1 -d -a
+openssl enc -aes-256-cbc -K $3 -iv $4 -in "$1" -out "$2" -d

--- a/client/src/scripts/encrypt_file.sh
+++ b/client/src/scripts/encrypt_file.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-openssl enc -aes-256-cbc -K $3 -iv $4 -in $1 -out $2 -a
+openssl enc -aes-256-cbc -K $3 -iv $4 -in "$1" -out "$2"

--- a/client/src/scripts/extract_pub.sh
+++ b/client/src/scripts/extract_pub.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-openssl rsa -outform PEM -pubout -passin file:$1
+openssl rsa -outform PEM -pubout -in $1 -passin file:$2

--- a/client/src/scripts/gen_pk.sh
+++ b/client/src/scripts/gen_pk.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-openssl genrsa -aes256 -passout file:$1
+openssl genrsa -aes256 -passout file:$1 -out $2

--- a/client/src/utils/recordUtils.ts
+++ b/client/src/utils/recordUtils.ts
@@ -3,7 +3,7 @@ import { getKeyForRecord } from "../api/records";
 import { file } from "tmp-promise";
 import { IPFSFile } from "ipfs";
 import util from "util";
-const exec = util.promisify(require("child_process").exec);
+const execFile = util.promisify(require("child_process").execFile);
 const writeFile = util.promisify(require("fs").writeFile);
 
 export interface TmpFile {
@@ -11,51 +11,62 @@ export interface TmpFile {
   cleanup: () => void;
 }
 
-export async function downloadRecord(recordHash: string, recordId: string) : Promise<TmpFile> {
+export async function downloadRecord(
+  recordHash: string,
+  recordId: string
+): Promise<TmpFile> {
   try {
     const ipfs = await getIpfs();
     const files = await ipfs.files.get(recordHash);
     if (files.length !== 1) {
-      Promise.reject(new Error(`More than one file found for hash: ${recordHash}`));
+      Promise.reject(
+        new Error(`More than one file found for hash: ${recordHash}`)
+      );
     }
     return downloadFile(files[0], recordId);
-  }
-  catch (err) {
+  } catch (err) {
     return Promise.reject(err);
   }
 }
 
-async function downloadFile(ipfsFile: IPFSFile, recordId: string): Promise<TmpFile> {
+async function downloadFile(
+  ipfsFile: IPFSFile,
+  recordId: string
+): Promise<TmpFile> {
   if (!ipfsFile.content) {
     return Promise.reject(new Error("No content in downloaded IPFS file."));
   }
-  const { path: outPath, cleanup: outCleanup } = await file({
-    mode: 0o644,
-    prefix: "medfstmp-"
-  });
-
-  const decryptedContents = await decryptFile(ipfsFile.content as string, recordId);
   try {
-    await writeFile(outPath, decryptedContents);
-    return {"path": outPath, "cleanup": outCleanup};
-  }
-  catch (err) {
+    const decryptedContents = await decryptFile(
+      ipfsFile.content as string,
+      recordId
+    );
+    return decryptedContents;
+  } catch (err) {
     return Promise.reject(err);
   }
 }
 
-async function decryptFile(encryptedContent: string, recordId: string): Promise<string> {
+async function decryptFile(
+  encryptedContent: string,
+  recordId: string
+): Promise<TmpFile> {
   const keyAndIv = await getKeyForRecord(recordId);
   const { path: encPath, cleanup: encCleanup } = await file({
     mode: 0o644,
     prefix: "medfstmp-"
   });
   await writeFile(encPath, encryptedContent);
-  const decryptedContents = await exec(
-    `src/scripts/decrypt_file.sh "${encPath}" "${keyAndIv.aesKey}" "${
-      keyAndIv.iv
-    }"`
-  );
+  const { path: outPath, cleanup: outCleanup } = await file({
+    mode: 0o644,
+    prefix: "medfstmp-"
+  });
+  await execFile("src/scripts/decrypt_file.sh", [
+    encPath,
+    outPath,
+    keyAndIv.aesKey,
+    keyAndIv.iv
+  ]);
   encCleanup();
-  return decryptedContents.stdout;
+  return { path: outPath, cleanup: outCleanup };
 }


### PR DESCRIPTION
Fixes the issues with encryption related to binary files by properly writing to tmp files and not casting them to strings throughout the pipeline.

Also fixes the bugs with spaces in paths (which appeared to still be around) by adding quotes to the bash scripts.

Finally, execFile seemed nicer as we can pass an arg list rather than string, so moved to using that.