### PR TITLE
Adds loading to record view card

### DIFF
--- a/client/src/renderer/records/records.tsx
+++ b/client/src/renderer/records/records.tsx
@@ -18,6 +18,7 @@ export type RecordListState = {
   permissionsModalVisible: boolean;
   currentRecord?: RecordItem;
   currentPermissions: Permission[];
+  loading: boolean;
 };
 
 export interface RecordProps {
@@ -32,18 +33,20 @@ export class Records extends React.Component<RecordProps, RecordListState> {
     this.state = {
       records: [],
       permissionsModalVisible: false,
-      currentPermissions: []
+      currentPermissions: [],
+      loading: true
     };
   }
 
   getAllRecords = () => {
     getAllForUser()
-      .then(records => this.setState({ records }))
+      .then(records => this.setState({ records, loading: false }))
       .catch((error: Error) => {
         if (error.message === ERR_NOT_AUTHORIZED) {
           this.props.updateIsLoggedIn(undefined);
         }
         console.error(error);
+        this.setState({ loading: false });
       });
   };
 
@@ -125,6 +128,7 @@ export class Records extends React.Component<RecordProps, RecordListState> {
           <Route exact path="/">
             <Card
               title="My Documents"
+              loading={this.state.loading}
               extra={
                 <Link to="/uploads">
                   <Button type="primary" icon="plus">


### PR DESCRIPTION
When records are still loading our list would say "no records found." Cards have built in loading states allowing us to indicate when fetching is still happening:

![out](https://user-images.githubusercontent.com/7549938/52919962-cec5c080-32d5-11e9-9f52-a005910dc631.gif)
