### PR TITLE
Adds notification previews

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "description": "medfs_client in electron",
   "scripts": {
     "dev": "electron-webpack dev",
+    "prod": "MEDFS_ENVIRONMENT=prod electron-webpack dev",
     "compile": "electron-webpack",
     "dist": "yarn compile && electron-builder",
     "dist:dir": "yarn dist --dir -c.compression=store -c.mac.identity=null",

--- a/client/settings.json
+++ b/client/settings.json
@@ -1,5 +1,8 @@
 {
-	"[tsx]": {
-		"editor.tabSize": 2
-	}
+  "[tsx]": {
+    "editor.tabSize": 2
+  },
+  "files.exclude": {
+    "**/node_modules": true
+  }
 }

--- a/client/src/models/notifications.ts
+++ b/client/src/models/notifications.ts
@@ -1,6 +1,9 @@
 export interface MedFsNotification {
-    type: string;
-    recordId: string;
-    privateKey: string;
-    name: string;
+  type: string;
+  recordId: string;
+  privateKey: string;
+  email: string;
+  encryptedAesKey: string;
+  iv: string;
+  filename: string;
 }

--- a/client/src/renderer/home/header.tsx
+++ b/client/src/renderer/home/header.tsx
@@ -5,6 +5,7 @@ import "antd/dist/antd.css";
 import { MedFsNotification } from "../../models/notifications";
 import { HistoryProps } from "../app";
 import * as _ from "lodash";
+import { NotificationPreview } from "./notification_preview";
 
 const { Header } = Layout;
 const logo = require("../../image/logo_white.png");
@@ -21,33 +22,12 @@ export class MedFsHeader extends React.Component<
   HeaderProps & HistoryProps,
   {}
 > {
-  getKey = (item: MedFsNotification): string => {
-    return item.recordId;
-  };
-
-  getName = (item: MedFsNotification): string => {
-    return item.name;
-  };
-
   notificationMenu() {
-    // TODO: do something with the private keys
-    const menuItems = (
-      <Menu style={{ borderRadius: "0px", textAlign: "center" }}>
-        {this.props.notifications.map(item => {
-          return (
-            <Menu.Item key={this.getKey(item)}>
-              <Link to={`/records/details/${this.getKey(item)}`}>
-                New file shared: {this.getName(item)}
-              </Link>
-            </Menu.Item>
-          );
-        })}
-      </Menu>
-    );
-
     return (
       <Dropdown
-        overlay={menuItems}
+        overlay={
+          <NotificationPreview notifications={this.props.notifications} />
+        }
         trigger={["click"]}
         onVisibleChange={this.props.clearNotifications}
       >

--- a/client/src/renderer/home/notification_preview.tsx
+++ b/client/src/renderer/home/notification_preview.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { Link } from "react-router-dom";
+import { Card, List } from "antd";
+import { MedFsNotification } from "../../models/notifications";
+
+interface Props {
+  notifications: MedFsNotification[];
+}
+
+export class NotificationPreview extends React.Component<Props, {}> {
+  renderItem = (item: MedFsNotification) => {
+    return (
+      <List.Item>
+        {/* TODO: refactor this wording once we have more granular notifications*/}
+        <Link to={`/records/details/${item.recordId}`}>
+          {item.email} shared {item.filename} with you
+        </Link>
+      </List.Item>
+    );
+  };
+
+  render() {
+    return (
+      <div>
+        <Card title="Notifications" size="small" style={{ width: 300 }}>
+          <List
+            dataSource={this.props.notifications}
+            renderItem={this.renderItem}
+          />
+        </Card>
+      </div>
+    );
+  }
+}

--- a/client/src/renderer/patients/patient_details.tsx
+++ b/client/src/renderer/patients/patient_details.tsx
@@ -27,7 +27,7 @@ type PatientDetailsProps = {
 export class PatientDetails extends React.Component<
   PatientDetailsProps,
   PatientDetailsState & RecordListState
-  > {
+> {
   constructor(props: PatientDetailsProps) {
     super(props);
 
@@ -35,21 +35,24 @@ export class PatientDetails extends React.Component<
       info: undefined,
       records: [],
       permissionsModalVisible: false,
-      currentPermissions: []
+      currentPermissions: [],
+      loading: false
     };
   }
 
   componentDidMount() {
     const patientId = this.props.match.params.patient_id;
 
-    Promise.all([getPatientInfo(patientId), getAllForPatient(patientId)]).then(results => {
-      this.setState({
-        info: results[0] as PatientInfo,
-        records: results[1] as RecordItem[],
+    Promise.all([getPatientInfo(patientId), getAllForPatient(patientId)])
+      .then(results => {
+        this.setState({
+          info: results[0] as PatientInfo,
+          records: results[1] as RecordItem[]
+        });
+      })
+      .catch(err => {
+        console.error(err);
       });
-    }).catch(err => {
-      console.error(err);
-    });
   }
 
   getPageTitle = (): string => {
@@ -60,15 +63,21 @@ export class PatientDetails extends React.Component<
       }
     }
     return "Patient Info";
-  }
+  };
 
   getDOB = () => {
     const info = this.state.info;
     if (info !== undefined && info.dateOfBirth !== null) {
-      return info.dateOfBirth.getFullYear() + "-" + (info.dateOfBirth.getMonth() + 1) + "-" + info.dateOfBirth.getDate();
+      return (
+        info.dateOfBirth.getFullYear() +
+        "-" +
+        (info.dateOfBirth.getMonth() + 1) +
+        "-" +
+        info.dateOfBirth.getDate()
+      );
     }
     return;
-  }
+  };
 
   tableColumns = (): Array<ColumnProps<RecordItem>> => {
     return [
@@ -146,22 +155,31 @@ export class PatientDetails extends React.Component<
             <Link to={`/uploads/${this.state.info && this.state.info.email}`}>
               <Button type="primary" icon="plus">
                 Add Document
-            </Button>
+              </Button>
             </Link>
           }
         >
           <Row gutter={32}>
             <Col span={6}>
-              <Statistic title="Email" value={this.state.info && this.state.info.email} />
+              <Statistic
+                title="Email"
+                value={this.state.info && this.state.info.email}
+              />
             </Col>
             <Col span={6}>
               <Statistic title="Date of Birth" value={this.getDOB()} />
             </Col>
             <Col span={6}>
-              <Statistic title="Blood Type" value={this.state.info && this.state.info.bloodType} />
+              <Statistic
+                title="Blood Type"
+                value={this.state.info && this.state.info.bloodType}
+              />
             </Col>
             <Col span={6}>
-              <Statistic title="Sex" value={this.state.info && this.state.info.sex} />
+              <Statistic
+                title="Sex"
+                value={this.state.info && this.state.info.sex}
+              />
             </Col>
           </Row>
 
@@ -171,7 +189,7 @@ export class PatientDetails extends React.Component<
             items={this.state.records}
             columns={this.tableColumns()}
             keyProp="id"
-            setPageTitle={() => { }}
+            setPageTitle={() => {}}
           />
         </Card>
 

--- a/record_service/record_service/endpoints/record_api.py
+++ b/record_service/record_service/endpoints/record_api.py
@@ -185,6 +185,7 @@ def upload_file():
                 "recordId": str(new_record.id),
                 "encryptedAesKey": values["encryptedAesKey"],
                 "iv": values["iv"],
+                "filename": data["filename"],
             }
         )
         queueing_api.send_message(user_uuid, msg)


### PR DESCRIPTION
Adds a couple things
1. `yarn prod` defaults us to prod mode, better for demoing
2. revamp of notification dropdown according to spec. There's no full page yet and a couple of rough edges but this gives us something to start with.

I think there should be some corresponding backend changes around how we persist notifications but that's out of this PRs scope. I'll try to add a full notifications page when I get a chance.

Don't mind the laggy gif

![out](https://user-images.githubusercontent.com/7549938/53307222-2fb84000-3864-11e9-8ac2-e4c557e15d92.gif)
 