### PR TITLE
Add commands to drop tables

### DIFF
--- a/acl_service/protos/acl.proto
+++ b/acl_service/protos/acl.proto
@@ -7,6 +7,11 @@ service Acl {
     rpc AddRecord (AddRecordRequest) returns (AddRecordResponse) {}
     rpc GetAllRecordsForUser (GetRecordsRequest) returns (ListOfRecords) {}
     rpc GetAllUsersForRecord (GetUsersRequest) returns (ListOfUsers) {}
+    rpc CleanDb(Empty) returns (Empty) {}
+}
+
+message Empty {
+
 }
 
 message UserId {

--- a/record_service/record_service/endpoints/utils_api.py
+++ b/record_service/record_service/endpoints/utils_api.py
@@ -1,10 +1,13 @@
 import hmac
 import hashlib
-import config
 import logging
 
 from flask import Blueprint, request, jsonify
+from record_service.database.database import db
+from record_service.models.base import Base
 from record_service.utils.responses import JsonResponse
+from record_service.external import acl_api, acl_pb2
+import config
 
 utils_api = Blueprint("utils_api", __name__)
 log = logging.getLogger()
@@ -19,13 +22,46 @@ def _verify(
     return hmac.compare_digest(sig, slack_signature)
 
 
+def clean_record_srv():
+    Base.metadata.drop_all(bind=db.engine)
+    Base.metadata.create_all(bind=db.engine)
+    return "cleaned record-srv db"
+
+
+def clean_acl_srv():
+    acl_client = acl_api.build_client(config.ACL_URL, config.ACL_PORT)
+    req = acl_pb2.Empty()
+    acl_client.CleanDb(req)
+    return "cleaned acl-srv db"
+
+
+commands = {
+    "clean-rec": [clean_record_srv],
+    "clean-acl": [clean_acl_srv],
+    "clean": [clean_record_srv, clean_acl_srv],
+}
+
+
 @utils_api.route("/utils", methods=["POST"])
 def handle_slash_command():
     data = request.get_data().decode("utf-8")
     slack_signature = request.headers.get("X-Slack-Signature", "")
     slack_request_timestamp = request.headers.get("X-Slack-Request-Timestamp", "")
+    req_str = request.form["text"].strip().lower()
 
     if not _verify(slack_signature, slack_request_timestamp, data):
         return JsonResponse(data="Unauthorized", status=401)
 
-    return jsonify(text="TODO", response_type="in_channel")
+    try:
+        command_list = commands[req_str]
+    except KeyError:
+        command_str = ", ".join(commands.keys())
+        return jsonify(
+            text=f"Invalid command {req_str} - valid commands are: {command_str}",
+            response_type="in_channel",
+        )
+
+    responses = [cmd() for cmd in command_list]
+    return jsonify(
+        text=f"Success! Actions: {', '.join(responses)}", response_type="in_channel"
+    )


### PR DESCRIPTION
Adds commands for slackbot to drop record-srv and acl-srv tables

Also my bad ignore the automatic formatting that happened in `acl_server.py`